### PR TITLE
Use `docker-compose exec` to enter hive-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This deploys a Presto server listens on port `8080`
 ## Testing
 Load data into Hive:
 ```
-  $ docker exec -it hive-server bash
+  $ docker-compose exec hive-server bash
   # /opt/hive/bin/beeline -u jdbc:hive2://localhost:10000
   > CREATE TABLE pokes (foo INT, bar STRING);
   > LOAD DATA LOCAL INPATH '/opt/hive/examples/files/kv1.txt' OVERWRITE INTO TABLE pokes;


### PR DESCRIPTION
Since `docker-compose.yml` does not set container name, `docker exec -it hiver-server` is impossible. Alternatively, we should pass container ID of the service as:

```
$ docker exec -it $(docker-compose ps -q hive-server) bash
```

Additionally, now `docker-compose exec` is more straightforward and easy-to-use option. So, this PR updates README so.