### PR TITLE
fix connect error to namenode:8020

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,11 @@ services:
     ports:
       - "8080:8080"
 
+networks:
+  default:
+    external:
+      name: docker-hadoop_default
+
 volumes:
   namenode:
   datanode:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set some sensible defaults
-export CORE_CONF_fs_defaultFS=${CORE_CONF_fs_defaultFS:-hdfs://`hostname -f`:8020}
+export CORE_CONF_fs_defaultFS=${CORE_CONF_fs_defaultFS:-hdfs://`hostname -f`:9000}
 
 function addProperty() {
   local path=$1

--- a/hadoop-hive.env
+++ b/hadoop-hive.env
@@ -6,7 +6,7 @@ HIVE_SITE_CONF_datanucleus_autoCreateSchema=false
 HIVE_SITE_CONF_hive_metastore_uris=thrift://hive-metastore:9083
 HDFS_CONF_dfs_namenode_datanode_registration_ip___hostname___check=false
 
-CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+CORE_CONF_fs_defaultFS=hdfs://namenode:9000
 CORE_CONF_hadoop_http_staticuser_user=root
 CORE_CONF_hadoop_proxyuser_hue_hosts=*
 CORE_CONF_hadoop_proxyuser_hue_groups=*


### PR DESCRIPTION
the CORE_CONF_fs_defaultFS(hdfs://namenode:9000) defined in docker-compose.yml is conflict with its dependency image(bde2020/hadoop-namenode:2.0.0-hadoop2.7.4-java8),so when the hive-server try to connet to the hadoop namenode, connection refuse exception occured.